### PR TITLE
Fix yarn command under setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Using global installation
 
 ```bash
 npm install -g eslint-ai # npm
-yarn add global eslint-ai # yarn
+yarn global add eslint-ai # yarn
 
 
 eslint-ai # basic usage


### PR DESCRIPTION
Fix the yarn add command.
With yarn, to perform global operations, all commands start with `yarn global`.
The original documented command is equal to `npm install "global" "eslint-ai"` which would install both to the local project.